### PR TITLE
Tweaks and enhancements to Curious

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .webassets-cache
 *.pyc
 .*.swp
+build
+*.egg-info*
+dist
+env

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - uname -a
     - lsb_release -a
     - sudo apt-get -qq update
-    - sudo apt-get -y install curl build-essential python-dev samtools '^zlib.*-dev$'
+    - sudo apt-get -y install bower python-dev 
 install:
     - pip install coveralls
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
     - 2.7
-services:
-    - mysql
 before_install:
     - date -u
     - uname -a
@@ -10,9 +8,8 @@ before_install:
     - sudo apt-get -qq update
     - sudo apt-get -y install bower python-dev 
 install:
-    - pip install coveralls
     - python setup.py install
 script:
-    - nosetests --with-coverage --cover-package=curious
+    - python tests/manage.py test
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+    - 2.7
+services:
+    - mysql
+before_install:
+    - date -u
+    - uname -a
+    - lsb_release -a
+    - sudo apt-get -qq update
+    - sudo apt-get -y install curl build-essential python-dev samtools '^zlib.*-dev$'
+install:
+    - pip install coveralls
+    - python setup.py install
+script:
+    - nosetests --with-coverage --cover-package=curious
+after_success:
+    - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ before_install:
     - uname -a
     - lsb_release -a
     - sudo apt-get -qq update
-    - sudo apt-get -y install bower python-dev 
+    - sudo apt-get -y install npm python-dev 
+    - npm install -g bower
 install:
     - python setup.py install
 script:

--- a/curious/parser.py
+++ b/curious/parser.py
@@ -34,21 +34,25 @@ from parsimonious.nodes import NodeVisitor
 
 class ASTBuilder(NodeVisitor):
 
-  def visit_query(self, node, (obj_query, _1, steps, _2)):
+  def visit_query(self, node, args):
+    (obj_query, _1, steps, _2) = args
     if type(steps) == list:
       return [obj_query]+steps[0]
     return [obj_query]
 
-  def visit_object_query(self, node, (model, filters)):
+  def visit_object_query(self, node, args):
+    (model, filters) = args
     return dict(model=model, method=None, filters=filters)
 
   def visit_filter_or_id(self, node, f_or_id):
     return f_or_id[0]
 
-  def visit_id_arg(self, node, (_1, _2, id, _3, _4)):
+  def visit_id_arg(self, node, args):
+    (_1, _2, id, _3, _4) = args
     return [dict(method='filter', kwargs=dict(id=id))]
 
-  def visit_steps(self, node, (step, another_steps)):
+  def visit_steps(self, node, args):
+    (step, another_steps) = args
     steps = [step]
     for s in another_steps:
       steps.append(s)
@@ -57,16 +61,19 @@ class ASTBuilder(NodeVisitor):
   def visit_step(self, node, q):
     return q[0]
 
-  def visit_another_step(self, node, (_1, step)):
+  def visit_another_step(self, node, args):
+    (_1, step) = args
     return step
 
   def visit_nj_steps(self, *args):
     return self.visit_steps(*args)
 
-  def visit_another_nj(self, node, (_1, nj_step)):
+  def visit_another_nj(self, node, args):
+    (_1, nj_step) = args
     return nj_step
 
-  def visit_join_query(self, node, (join, _1, nj_query)):
+  def visit_join_query(self, node, args):
+    (join, _1, nj_query) = args
     if type(join) == list:
       nj_query['join'] = True
     return nj_query
@@ -74,16 +81,19 @@ class ASTBuilder(NodeVisitor):
   def visit_nj_query(self, node, q):
     return q[0]
 
-  def visit_or_query(self, node, (_1, nj_steps_1, _2, _s1, _3, _s2, _4, nj_steps_2, _5, more_ors)):
+  def visit_or_query(self, node, args):
+    (_1, nj_steps_1, _2, _s1, _3, _s2, _4, nj_steps_2, _5, more_ors) = args
     r = dict(orquery=[nj_steps_1, nj_steps_2], join=False)
     if type(more_ors) == list:
       r['orquery'].extend(more_ors)
     return r
 
-  def visit_another_or(self, node, (_s1, _1, _s2, _2, nj_steps, _3)):
+  def visit_another_or(self, node, args):
+    (_s1, _1, _s2, _2, nj_steps, _3) = args
     return nj_steps
 
-  def visit_one_query(self, node, (one_rel, recursion)):
+  def visit_one_query(self, node, args):
+    (one_rel, recursion) = args
     if type(recursion) == list:
       one_rel['recursive'] = True
       if recursion[0] == '$':
@@ -96,21 +106,24 @@ class ASTBuilder(NodeVisitor):
         one_rel['collect'] = 'all'
     return one_rel
 
-  def visit_one_rel(self, node, (model, _1, method, filters)):
+  def visit_one_rel(self, node, args):
+    (model, _1, method, filters) = args
     if type(filters) != list:
       filters = None
     else:
       filters = filters[0]
     return dict(model=model, method=method, filters=filters)
 
-  def visit_sub_query(self, node, (modifier, _1, q, _2)):
+  def visit_sub_query(self, node, args):
+    (modifier, _1, q, _2) = args
     join = False
     having = None
     if type(modifier) == list:
       having = modifier[0]
     return dict(subquery=q, having=having, join=join)
 
-  def visit_filters(self, node, (f, more_filters)):
+  def visit_filters(self, node, args):
+    (f, more_filters) = args
     filters = []
     if type(f) == list:
       f[0]['method'] = 'filter'
@@ -119,18 +132,21 @@ class ASTBuilder(NodeVisitor):
       filters.extend(more_filters[0])
     return filters
 
-  def visit_name_filters(self, node, (f, more_filters)):
+  def visit_name_filters(self, node, args):
+    (f, more_filters) = args
     filters = []
     filters.append(f)
     if type(more_filters) == list:
       filters.extend(more_filters)
     return filters
 
-  def visit_name_filter(self, node, (_1, method, f)):
+  def visit_name_filter(self, node, args):
+    (_1, method, f) = args
     f['method'] = method
     return f
 
-  def visit_filter_group(self, node, (_1, args, _2)):
+  def visit_filter_group(self, node, args):
+    (_1, args, _2) = args
     return args
 
   def visit_recursion(self, node, _):
@@ -144,18 +160,21 @@ class ASTBuilder(NodeVisitor):
       return {'kwargs': args[0]}
     return {'field': args[0]}
 
-  def visit_filter_kvs(self, node, (_1, arg, more_args, _2)):
+  def visit_filter_kvs(self, node, args):
+    (_1, arg, more_args, _2) = args
     d = arg
     for a in more_args:
       d.update(a)
     return d
 
-  def visit_arg(self, node, (arg_name, _1, equal, _2, value)):
+  def visit_arg(self, node, args):
+    (arg_name, _1, equal, _2, value) = args
     d = {}
     d[arg_name] = value
     return d
 
-  def visit_another_arg(self, node, (_1, comma, _2, arg)):
+  def visit_another_arg(self, node, args):
+    (_1, comma, _2, arg) = args
     return arg
 
   def visit_sub_modifier(self, node, _):
@@ -170,12 +189,14 @@ class ASTBuilder(NodeVisitor):
   def visit_values(self, node, val):
     return val[0]
 
-  def visit_array_value(self, node, (br1, _1, value, more_values, _2, br2)):
+  def visit_array_value(self, node, args):
+    (br1, _1, value, more_values, _2, br2) = args
     if type(more_values) != list:
       more_values = []
     return [value]+more_values
 
-  def visit_another_val(self, node, (_1, comma, _2, value)):
+  def visit_another_val(self, node, args):
+    (_1, comma, _2, value) = args
     return value
 
   def visit_value(self, node, value):
@@ -193,7 +214,8 @@ class ASTBuilder(NodeVisitor):
   def visit_float(self, node, _):
     return float(node.text)
 
-  def visit_string(self, node, (t, s)):
+  def visit_string(self, node, args):
+    (t, s) = args
     if type(t) == list:
       if t[0].text == 't':
         c = parsedatetime.Calendar()
@@ -206,10 +228,12 @@ class ASTBuilder(NodeVisitor):
   def visit_q_string(self, node, s):
     return s[0]
 
-  def visit_dq_string(self, node, (q0, v, q1)):
+  def visit_dq_string(self, node, args):
+    (q0, v, q1) = args
     return v.text
 
-  def visit_sq_string(self, node, (q0, v, q1)):
+  def visit_sq_string(self, node, args):
+    (q0, v, q1) = args
     return v.text
 
   def generic_visit(self, node, visited_children):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@
 Django == 1.6
 django-nose
 
+# nose coverage
+coveralls
+
 # humanize dates
 humanize
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+install = install_bower install

--- a/tests/dummy/settings.py
+++ b/tests/dummy/settings.py
@@ -41,6 +41,10 @@ INSTALLED_APPS = (
     'django_nose'
 )
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-package=curious',
+]
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
The main motivation to this pull are the changes required to make `parser.py` python 2/3 compliant.  Since `parser.py` is users verbatim in `curious-client`, and since some `curious-client` users use python3, I had to modify `parser.py` to make it compliant with python3 syntax.  As curious changes, I want to be able to pull in `parser.py` into `curious-client` without having to make these same modifications.  The changes are basically cosmetic.  I also brushed up `setup.py` to support bower installations, and added hooks to travis CI.  All tests pass except for one that was failing prior to these changes.
